### PR TITLE
Update vl-alert.src.js

### DIFF
--- a/vl-alert.src.js
+++ b/vl-alert.src.js
@@ -1,4 +1,4 @@
-import { VlElement } from '/node_modules/vl-ui-core/vl-core.src.js';
+import { VlElement } from '/node_modules/vl-ui-core/vl-core.js';
 
 /**
  * vl-alert


### PR DESCRIPTION
Ik had de ui-input-field hier van gekopieerd, maar hier staat ook import vl-core-src.js. Ik vermoed dat dit hier ook de gebuilde versie moet zijn, en niet de src.